### PR TITLE
Finish URL loading when observing requests to make sure all URL reque…

### DIFF
--- a/FeedAppTests/URLSessionHTTPClientTests.swift
+++ b/FeedAppTests/URLSessionHTTPClientTests.swift
@@ -176,7 +176,6 @@ class URLSessionHTTPClientTests: XCTestCase {
         }
 
         override class func canInit(with request: URLRequest) -> Bool {
-            requestObserver?(request)
             return true
         }
 
@@ -185,6 +184,11 @@ class URLSessionHTTPClientTests: XCTestCase {
         }
 
         override func startLoading() {
+            if let requestObserver = URLProtocolStub.requestObserver {
+                client?.urlProtocolDidFinishLoading(self)
+                return requestObserver(request)
+            }
+
             if let data = URLProtocolStub.stub?.data {
                 client?.urlProtocol(self, didLoad: data)
             }

--- a/Test Plans/CI.xctestplan
+++ b/Test Plans/CI.xctestplan
@@ -17,7 +17,8 @@
           "name" : "FeedApp"
         }
       ]
-    }
+    },
+    "threadSanitizerEnabled" : true
   },
   "testTargets" : [
     {

--- a/Test Plans/FeedApp.xctestplan
+++ b/Test Plans/FeedApp.xctestplan
@@ -4,7 +4,14 @@
       "id" : "2C23496B-F89F-4DCB-9B39-09E7B7FBF813",
       "name" : "Configuration 1",
       "options" : {
-
+        "guardMallocEnabled" : false,
+        "mallocGuardEdgesEnabled" : false,
+        "mallocScribbleEnabled" : false,
+        "mallocStackLoggingOptions" : null,
+        "maximumTestRepetitions" : 50,
+        "testExecutionOrdering" : "alphabetical",
+        "testRepetitionMode" : "untilFailure",
+        "threadSanitizerEnabled" : false
       }
     }
   ],
@@ -17,7 +24,15 @@
           "name" : "FeedApp"
         }
       ]
-    }
+    },
+    "guardMallocEnabled" : true,
+    "mallocGuardEdgesEnabled" : true,
+    "mallocScribbleEnabled" : true,
+    "mallocStackLoggingOptions" : {
+      "loggingType" : "allAllocations"
+    },
+    "nsZombieEnabled" : true,
+    "threadSanitizerEnabled" : true
   },
   "testTargets" : [
     {


### PR DESCRIPTION
…sts are finished before the test method returns. This way, we prevent data races with threads living longer than the test method that initiated them.