### PR TITLE
Synchronize access to global URLProtocolStub.stub with a private `Dis…

### DIFF
--- a/FeedAppTests/URLSessionHTTPClientTests.swift
+++ b/FeedAppTests/URLSessionHTTPClientTests.swift
@@ -132,7 +132,7 @@ class URLSessionHTTPClientTests: XCTestCase {
     }
 
     private func anyData() -> Data {
-        return Data(bytes: "any data".utf8)
+        return Data("any data".utf8)
     }
 
     private func anyNSError() -> NSError {
@@ -148,21 +148,27 @@ class URLSessionHTTPClientTests: XCTestCase {
     }
 
     private class URLProtocolStub: URLProtocol {
-        private static var stub: Stub?
-        private static var requestObserver: ((URLRequest) -> Void)?
+        
+        private static var _stub: Stub?
+        private static var stub: Stub? {
+            get { queue.sync { _stub } }
+            set { queue.sync { _stub = newValue } }
+        }
+        private static let queue = DispatchQueue(label: "URLProtocolStub.queue")
 
         private struct Stub {
             let data: Data?
             let response: URLResponse?
             let error: Error?
+            let requestObserver: ((URLRequest) -> Void)?
         }
 
         static func stub(data: Data?, response: URLResponse?, error: Error?) {
-            stub = Stub(data: data, response: response, error: error)
+            stub = Stub(data: data, response: response, error: error, requestObserver: nil)
         }
 
         static func observeRequests(observer: @escaping (URLRequest) -> Void) {
-            requestObserver = observer
+            stub = Stub(data: nil, response: nil, error: nil, requestObserver: observer)
         }
 
         static func startInterceptingRequests() {
@@ -172,7 +178,6 @@ class URLSessionHTTPClientTests: XCTestCase {
         static func stopInterceptingRequests() {
             URLProtocol.unregisterClass(URLProtocolStub.self)
             stub = nil
-            requestObserver = nil
         }
 
         override class func canInit(with request: URLRequest) -> Bool {
@@ -184,24 +189,23 @@ class URLSessionHTTPClientTests: XCTestCase {
         }
 
         override func startLoading() {
-            if let requestObserver = URLProtocolStub.requestObserver {
-                client?.urlProtocolDidFinishLoading(self)
-                return requestObserver(request)
-            }
+            guard let stub = URLProtocolStub.stub else { return }
 
-            if let data = URLProtocolStub.stub?.data {
+            if let data = stub.data {
                 client?.urlProtocol(self, didLoad: data)
             }
 
-            if let response = URLProtocolStub.stub?.response {
+            if let response = stub.response {
                 client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             }
 
-            if let error = URLProtocolStub.stub?.error {
+            if let error = stub.error {
                 client?.urlProtocol(self, didFailWithError: error)
+            } else {
+                client?.urlProtocolDidFinishLoading(self)
             }
 
-            client?.urlProtocolDidFinishLoading(self)
+            stub.requestObserver?(request)
         }
 
         override func stopLoading() {}


### PR DESCRIPTION
Synchronize access to global URLProtocolStub.stub with a private `DispatchQueue` to prevent data races